### PR TITLE
feat: Fix fish-eye, use linear perspective 

### DIFF
--- a/cmd/redcaster_test.go
+++ b/cmd/redcaster_test.go
@@ -195,7 +195,7 @@ func Test_RendererCalculateRayAngle(t *testing.T) {
 
 			r := NewRenderer(&game)
 
-			got := r.calculateRayAngle(tc.screenColumn)
+			got := r.computeRayAngle(tc.screenColumn)
 
 			if !aproximately(tc.expected, got) {
 				t.Errorf("Expected %f, got %f", tc.expected, got)
@@ -421,7 +421,7 @@ func Test_RendererCalculateVerticalCollisionRayLength(t *testing.T) {
 			r := NewRenderer(&game)
 
 			//fmt.Println(tc.name)
-			got := r.calculateVerticalCollisionRayLength(tc.pX, tc.pY, tc.rAngle)
+			got := r.computeVerticalCollisionRayLength(tc.pX, tc.pY, tc.rAngle)
 
 			if !aproximately(tc.expected, got) {
 				t.Errorf("Expected %f, got %f", tc.expected, got)


### PR DESCRIPTION
* Use cosine ray length projection to fix the fish-eye effect.
* Use linear perspective "sampling" instead of linear ray angle increment for determining the ray angle.
* Chang the map a bit to make it more interesting.